### PR TITLE
Only let Dependabot update weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
-    time: "07:00"
+    interval: weekly
   open-pull-requests-limit: 10
   groups:
     all-go-mod-patch-and-minor:


### PR DESCRIPTION
daily updates are a bit too spammy, only allow weekly updates.