### PR TITLE
Remove references to registry.opensource.zalan.do

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
   # Ignore k8s and its transitives modules as they are upgraded manually
   - dependency-name: "k8s.io/*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  groups:
+    github-actions:
+      patterns:
+        - "*"

--- a/.github/workflows/gh-packages.yaml
+++ b/.github/workflows/gh-packages.yaml
@@ -1,0 +1,89 @@
+name: gh-package-deploy
+permissions: {}
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: "${{ github.repository }}"
+
+jobs:
+  docker:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+
+    runs-on: ubuntu-latest
+    # Adding this block will overridw default values to None if not specified in the block
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      contents: read
+      actions: read
+      packages: write # to push packages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          # https://www.npmjs.com/package/semver#caret-ranges-123-025-004
+          go-version: '^1.26'
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435
+        id: get-latest-tag
+
+      - name: Build binaries
+        run: |
+          make build.linux.amd64 build.linux.arm64
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Build and push latest tag
+      - name: Build and push latest
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=registry.opensource.zalan.do/library/static:latest
+ARG BASE_IMAGE=gcr.io/distroless/static-debian12:latest
 FROM ${BASE_IMAGE}
 
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY        ?= kube-aws-iam-controller
 VERSION       ?= $(shell git describe --tags --always --dirty)
-IMAGE         ?= registry-write.opensource.zalan.do/teapot/$(BINARY)
+IMAGE         ?= ghrc.io/zalando-incubator/$(BINARY)
 TAG           ?= $(VERSION)
 SOURCES       = $(shell find . -name '*.go')
 GENERATED     = pkg/client pkg/apis/zalando.org/v1/zz_generated.deepcopy.go

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -13,19 +13,6 @@ pipeline:
   - desc: test & check
     cmd: |
       make test
-  - desc: build
-    cmd: |
-      make build.docker
-  - desc: Build and push image to PierOne
-    cmd: |
-      if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
-        IMAGE=registry-write.opensource.zalan.do/teapot/kube-aws-iam-controller
-        VERSION=$(git describe --tags --always --dirty)
-      else
-        IMAGE=registry-write.opensource.zalan.do/teapot/kube-aws-iam-controller-test
-        VERSION=$CDP_BUILD_VERSION
-      fi
-      IMAGE=$IMAGE VERSION=$VERSION make build.push
   - desc: Build and push image to Zalando's registry
     cmd: |
       if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then

--- a/docs/deployment.yaml
+++ b/docs/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-aws-iam-controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-iam-controller:latest
+        image: ghrc.io/zalando-incubator/kube-aws-iam-controller:latest
         resources:
           limits:
             cpu: 25m

--- a/docs/deployment_with_role.yaml
+++ b/docs/deployment_with_role.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: kube-aws-iam-controller
       containers:
       - name: kube-aws-iam-controller
-        image: registry.opensource.zalan.do/teapot/kube-aws-iam-controller:latest
+        image: ghrc.io/zalando-incubator/kube-aws-iam-controller:latest
         env:
         # must be set for the AWS SDK/AWS CLI to find the credentials file.
         - name: AWS_SHARED_CREDENTIALS_FILE


### PR DESCRIPTION
Zalando wants to decommission the docker registry hosting images on `registry.opensource.zalan.do`

This removes any reference to `registry.opensource.zalan.do` and replaces with open source images where applicable.

We will provide public images via ghcr.io. A github action is added to build and push those images.